### PR TITLE
typo fix: replace includes.yml with includes.md

### DIFF
--- a/.claude/commands/simpleclaude/TEMPLATE.md
+++ b/.claude/commands/simpleclaude/TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.claude/commands/simpleclaude/sc-create.md
+++ b/.claude/commands/simpleclaude/sc-create.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.claude/commands/simpleclaude/sc-fix.md
+++ b/.claude/commands/simpleclaude/sc-fix.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.claude/commands/simpleclaude/sc-modify.md
+++ b/.claude/commands/simpleclaude/sc-modify.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.claude/commands/simpleclaude/sc-review.md
+++ b/.claude/commands/simpleclaude/sc-review.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.claude/commands/simpleclaude/sc-understand.md
+++ b/.claude/commands/simpleclaude/sc-understand.md
@@ -2,7 +2,7 @@
 
 ---
 
-@include shared/simpleclaude/includes.yml
+@include shared/simpleclaude/includes.md
 
 ## Command Execution
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 # Ignore SimpleClaude includes file as it uses custom @include syntax
-.claude/shared/simpleclaude/includes.yml
+.claude/shared/simpleclaude/includes.md

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -185,7 +185,7 @@ You can also manually test specific includes:
 claude -p --output-format json "Can you see @include shared/simpleclaude/modes.yml"
 
 # Test nested include resolution
-claude -p --output-format json "What's in the mcp_tools_directive from includes.yml?"
+claude -p --output-format json "What's in the mcp_tools_directive from includes.md?"
 
 # Test command functionality
 claude -p "Using sc-understand command structure, analyze this: explain authentication"

--- a/test-commands.sh
+++ b/test-commands.sh
@@ -74,17 +74,17 @@ test_includes() {
   echo "-------------------------------------"
 
   run_claude_test \
-    "Can you see the content from this include directive: @include shared/simpleclaude/includes.yml" \
-    "includes.yml" \
+    "Can you see the content from this include directive: @include shared/simpleclaude/includes.md" \
+    "includes.md" \
     "Basic @include recognition"
 
   run_claude_test \
-    "When you process @include shared/simpleclaude/includes.yml, can you see the actual content from the nested includes like the MCP tools directive from sub-agents.yml?" \
+    "When you process @include shared/simpleclaude/includes.md, can you see the actual content from the nested includes like the MCP tools directive from sub-agents.yml?" \
     "mcp_tools_directive" \
     "Nested @include resolution"
 
   run_claude_test \
-    "In the SimpleClaude system loaded via @include shared/simpleclaude/includes.yml, what are the 4 sub-agent types defined?" \
+    "In the SimpleClaude system loaded via @include shared/simpleclaude/includes.md, what are the 4 sub-agent types defined?" \
     "researcher.*coder" \
     "Access to deeply nested content"
 


### PR DESCRIPTION
**fix a typo.** 

Although Claude Code eventually finds the file, it takes an extra loop to correct the typo.