### PR TITLE
Fix install script arithmetic bug causing early exit

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,10 +206,10 @@ install_directory() {
               cp "$file" "$target_file"
               echo "    Updated: $basename_file"
             fi
-            ((updated_count++))
+            ((updated_count++)) || true
           else
             echo "    Unchanged: $basename_file"
-            ((unchanged_count++))
+            ((unchanged_count++)) || true
           fi
         else
           # New file
@@ -219,7 +219,7 @@ install_directory() {
             cp "$file" "$target_file"
             echo "    Added: $basename_file"
           fi
-          ((added_count++))
+          ((added_count++)) || true
         fi
       fi
     done


### PR DESCRIPTION
## Bug
Install script failed after README.md - nothing else was installed.

## Cause  
`((count++))` with count=0 returns 0, which fails under `set -e`, exiting the script early.

## Fix
Added `|| true` to count increments to prevent early exit.

## Tested
Ubuntu 22.04, Bash 5.2.21. All files now install correctly. Should work everywhere since it's standard bash behavior, but extra testing welcome.